### PR TITLE
fix(ci): Fix terraform init failing on apply

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -83,10 +83,7 @@ jobs:
 
     - name: Terraform Init
       run: |
-        terraform init \
-          -backend-config="bucket=${BACKEND_BUCKET}" \
-          -backend-config="key=aws/backend/default.tfstate" \
-          -backend-config="region=ca-central-1"
+        terraform init
 
     - name: Terraform Plan
       run: terraform plan -out terraform.tfplan


### PR DESCRIPTION
The s3 state is hardcoded in the providers.tf so there is no github secret.