### PR TITLE
fix: add key claim token secret to retrieval svc

### DIFF
--- a/server/aws/task-definitions/covidshield_key_retrieval.json
+++ b/server/aws/task-definitions/covidshield_key_retrieval.json
@@ -36,6 +36,10 @@
       ],
       "secrets": [
         {
+          "name": "KEY_CLAIM_TOKEN",
+          "valueFrom": "${key_claim_token}"
+        },
+        {
           "name": "RETRIEVE_HMAC_KEY",
           "valueFrom": "${retrieve_hmac_key}"
         },


### PR DESCRIPTION
Adds the key claim token to the secrets for the retrieval svc.