### PR TITLE
fix: add `-input=false`

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -53,7 +53,7 @@ jobs:
         run: terraform fmt -check
 
       - name: Terraform Plan
-        run: terraform plan
+        run: terraform plan -input=false
 
   terraform-security-scan:
     if: github.ref != 'refs/heads/master'
@@ -88,7 +88,7 @@ jobs:
         terraform init
 
     - name: Terraform Plan
-      run: terraform plan -out terraform.tfplan
+      run: terraform plan -input=false -out terraform.tfplan
 
     - name: Terraform Apply
-      run: terraform apply -auto-approve terraform.tfplan
+      run: terraform apply -input=false -auto-approve terraform.tfplan


### PR DESCRIPTION
Fixes an issue where the workflow would hang if some variables were missing 

Now it errors out
