### PR TITLE
feat: add second cert validation to help with migration

### DIFF
--- a/server/aws/certificates.tf
+++ b/server/aws/certificates.tf
@@ -37,6 +37,14 @@ resource "aws_route53_record" "covidshield_certificate_validation" {
   ttl     = 60
 }
 
+resource "aws_route53_record" "covidshield_certificate_validation_2" {
+  zone_id = aws_route53_zone.covidshield.zone_id
+  name    = aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_name
+  type    = aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_type
+  records = [aws_acm_certificate.covidshield.domain_validation_options.1.resource_record_value]
+  ttl     = 60
+}
+
 resource "aws_route53_record" "retrieval_covidshield_certificate_validation" {
   zone_id = aws_route53_zone.covidshield.zone_id
   name    = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_name


### PR DESCRIPTION
Create new ACM Validation resource so we don't have to create and destroy resources when migrating to the v3 provider

