### PR TITLE
fix: Sync with Staging

### DIFF
--- a/server/aws/certificates.tf
+++ b/server/aws/certificates.tf
@@ -30,34 +30,50 @@ resource "aws_acm_certificate" "retrieval_covidshield" {
 }
 
 resource "aws_route53_record" "covidshield_certificate_validation" {
-  zone_id         = aws_route53_zone.covidshield.zone_id
-  name            = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_name
-  type            = aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_type
-  records         = [aws_acm_certificate.covidshield.domain_validation_options.0.resource_record_value]
+  zone_id = aws_route53_zone.covidshield.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.covidshield.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
   allow_overwrite = true
-  ttl             = 60
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
 }
 
 resource "aws_route53_record" "retrieval_covidshield_certificate_validation" {
-  zone_id         = aws_route53_zone.covidshield.zone_id
-  name            = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_name
-  type            = aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_type
-  records         = [aws_acm_certificate.retrieval_covidshield.domain_validation_options.0.resource_record_value]
-  allow_overwrite = true
-  ttl             = 60
+  zone_id = aws_route53_zone.covidshield.zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.retrieval_covidshield.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+
+    }
+  }
+
+  name    = each.value.name
+  records = [each.value.record]
+  type    = each.value.type
+
+  ttl = 60
 }
 
 resource "aws_acm_certificate_validation" "covidshield" {
-  certificate_arn = aws_acm_certificate.covidshield.arn
-  validation_record_fqdns = [
-    aws_route53_record.covidshield_certificate_validation.fqdn
-  ]
+  certificate_arn         = aws_acm_certificate.covidshield.arn
+  validation_record_fqdns = [for record in aws_route53_record.covidshield_certificate_validation : record.fqdn]
 }
 
 resource "aws_acm_certificate_validation" "retrieval_covidshield" {
-  provider        = aws.us-east-1
-  certificate_arn = aws_acm_certificate.retrieval_covidshield.arn
-  validation_record_fqdns = [
-    aws_route53_record.retrieval_covidshield_certificate_validation.fqdn
-  ]
+  provider                = aws.us-east-1
+  certificate_arn         = aws_acm_certificate.retrieval_covidshield.arn
+  validation_record_fqdns = [for record in aws_route53_record.retrieval_covidshield_certificate_validation : record.fqdn]
 }

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -30,7 +30,7 @@ data "template_file" "covidshield_key_retrieval_task" {
   template = file("task-definitions/covidshield_key_retrieval.json")
 
   vars = {
-    image                 = "${local.retrieval_repo}"
+    image                 = local.retrieval_repo
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_retrieval_name}"
@@ -167,7 +167,7 @@ data "template_file" "covidshield_key_submission_task" {
   template = file("task-definitions/covidshield_key_submission.json")
 
   vars = {
-    image                 = "${local.submission_repo}"
+    image                 = local.submission_repo
     awslogs-group         = aws_cloudwatch_log_group.covidshield.name
     awslogs-region        = var.region
     awslogs-stream-prefix = "ecs-${var.ecs_key_submission_name}"

--- a/server/aws/networking.tf
+++ b/server/aws/networking.tf
@@ -26,7 +26,7 @@ resource "aws_vpc_endpoint" "ecr-dkr" {
   service_name        = "com.amazonaws.${var.region}.ecr.dkr"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = data.aws_subnet_ids.ecr_endpoint_available.ids
 }
@@ -37,7 +37,7 @@ resource "aws_vpc_endpoint" "ecr-api" {
   service_name        = "com.amazonaws.${var.region}.ecr.api"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = data.aws_subnet_ids.ecr_endpoint_available.ids
 }
@@ -48,7 +48,7 @@ resource "aws_vpc_endpoint" "kms" {
   service_name        = "com.amazonaws.${var.region}.kms"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -59,7 +59,7 @@ resource "aws_vpc_endpoint" "secretsmanager" {
   service_name        = "com.amazonaws.${var.region}.secretsmanager"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -77,7 +77,7 @@ resource "aws_vpc_endpoint" "logs" {
   service_name        = "com.amazonaws.${var.region}.logs"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }
@@ -88,7 +88,7 @@ resource "aws_vpc_endpoint" "monitoring" {
   service_name        = "com.amazonaws.${var.region}.monitoring"
   private_dns_enabled = true
   security_group_ids = [
-    "${aws_security_group.privatelink.id}",
+    aws_security_group.privatelink.id,
   ]
   subnet_ids = aws_subnet.covidshield_private.*.id
 }

--- a/server/aws/provider.tf
+++ b/server/aws/provider.tf
@@ -1,16 +1,16 @@
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.11"
   region  = var.region
 }
 
 provider "aws" {
-  version = "~> 2.0"
+  version = "~> 3.11"
   alias   = "us-east-1"
   region  = "us-east-1"
 }
 
 terraform {
-  required_version = "> 0.12.0"
+  required_version = "= 0.13.4"
 }
 
 terraform {

--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -581,7 +581,7 @@ resource "aws_wafv2_web_acl_association" "key_retrieval_assocation" {
 # AWS WAF - Logging
 ###
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.key_submission.arn
   redacted_fields {
     single_header {
@@ -591,13 +591,13 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval" {
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs.arn]
   resource_arn            = aws_wafv2_web_acl.key_retrieval.arn
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_retrieval_cdn" {
   provider = aws.us-east-1
 
-  log_destination_configs = ["${aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn}"]
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs_us_east.arn]
   resource_arn            = aws_wafv2_web_acl.key_retrieval_cdn.arn
 }


### PR DESCRIPTION
Manual work has already been done

- manual steps

1. `tf state mv 'aws_route53_record.retrieval_covidshield_certificate_validation' 'aws_route53_record.retrieval_covidshield_certificate_validation["retrieval.covid-alert-demo.cdssandbox.xyz"]'`
2. `tf state rm 'aws_route53_record.covidshield_certificate_validation'`

I have determined that this is the absolute minimum amount of manual state manipulation needed in order to successfully migrate to v3 provider2.
