### PR TITLE
Feat: Scale down and sync with staging

### DIFF
--- a/server/aws/cloudwatch.tf
+++ b/server/aws/cloudwatch.tf
@@ -322,6 +322,36 @@ resource "aws_cloudwatch_metric_alarm" "fatal_logged_warn" {
 }
 
 ###
+# AWS CloudWatch Metrics - Action alarms
+###
+
+resource "aws_cloudwatch_log_metric_filter" "key_clear_called" {
+  name           = "KeyClearCalled"
+  pattern        = "diagnosis_keys was truncated"
+  log_group_name = aws_cloudwatch_log_group.covidshield.name
+
+  metric_transformation {
+    name      = "KeyClearCalled"
+    namespace = "CovidShield"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "key_clear_called_warn" {
+  alarm_name          = "KeyClearCalledWarn"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.key_clear_called.name
+  namespace           = "CovidShield"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  alarm_description   = "This metric monitors for a key clear calls (only be called in staging)"
+
+  alarm_actions = [aws_sns_topic.alert_warning.arn, aws_sns_topic.alert_critical.arn]
+}
+
+###
 # AWS CloudWatch Metrics - DDoS Alarms
 ###
 

--- a/server/aws/ecs.tf
+++ b/server/aws/ecs.tf
@@ -48,8 +48,8 @@ data "template_file" "covidshield_key_retrieval_task" {
 
 resource "aws_ecs_task_definition" "covidshield_key_retrieval" {
   family       = var.ecs_key_retrieval_name
-  cpu          = 2048
-  memory       = "4096"
+  cpu          = var.cpu_units
+  memory       = var.memory
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -77,7 +77,7 @@ resource "aws_ecs_service" "covidshield_key_retrieval" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 3
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -176,13 +176,14 @@ data "template_file" "covidshield_key_submission_task" {
     metric_provider       = var.metric_provider
     tracer_provider       = var.tracer_provider
     env                   = var.environment
+    enable_test_tools     = var.enable_test_tools
   }
 }
 
 resource "aws_ecs_task_definition" "covidshield_key_submission" {
   family       = var.ecs_key_submission_name
-  cpu          = 2048
-  memory       = "4096"
+  cpu          = var.cpu_units
+  memory       = var.memory
   network_mode = "awsvpc"
 
   requires_compatibilities = ["FARGATE"]
@@ -210,7 +211,7 @@ resource "aws_ecs_service" "covidshield_key_submission" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 3
+  desired_count                      = 1
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60

--- a/server/aws/metrics.tf
+++ b/server/aws/metrics.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalWarn" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "250"
+  threshold           = var.unclaimed_one_time_code_total_warn
   alarm_description   = "This metric monitors for total unclaimed codes"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn]
@@ -71,7 +71,7 @@ resource "aws_cloudwatch_metric_alarm" "UnclaimedOneTimeCodeTotalCritical" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "400"
+  threshold           = var.unclaimed_one_time_code_total_critical
   alarm_description   = "This metric monitors for total unclaimed codes"
 
   alarm_actions = [aws_sns_topic.alert_critical.arn]
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalWarn" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "3000"
+  threshold           = var.claimed_one_time_code_total_warn
   alarm_description   = "This metric monitors for total claimed codes"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn]
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_metric_alarm" "ClaimedOneTimeCodeTotalCritical" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "4500"
+  threshold           = var.claimed_one_time_code_total_critical
   alarm_description   = "This metric monitors for total claimed codes"
 
   alarm_actions = [aws_sns_topic.alert_critical.arn]
@@ -141,7 +141,7 @@ resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalWarn" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "9000"
+  threshold           = var.diagnosis_key_total_warn
   alarm_description   = "This metric monitors for total diagnosis keys"
 
   alarm_actions = [aws_sns_topic.alert_warning.arn]
@@ -155,7 +155,7 @@ resource "aws_cloudwatch_metric_alarm" "DiagnosisKeyTotalCritical" {
   namespace           = "CovidShield"
   period              = "60"
   statistic           = "Maximum"
-  threshold           = "13500"
+  threshold           = var.diagnosis_key_total_critical
   alarm_description   = "This metric monitors for total diagnosis keys"
 
   alarm_actions = [aws_sns_topic.alert_critical.arn]

--- a/server/aws/task-definitions/covidshield_key_submission.json
+++ b/server/aws/task-definitions/covidshield_key_submission.json
@@ -39,6 +39,10 @@
         {
           "name": "ENV",
           "value": "${env}"
+        },
+        {
+          "name": "ENABLE_TEST_TOOLS",
+          "value": "${enable_test_tools}"
         }
       ],
       "secrets": [

--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -38,6 +38,9 @@ ecs_key_submission_name = "KeySubmission"
 
 submission_autoscale_enabled = true
 retrieval_autoscale_enabled  = true
+min_capacity                 = 1
+cpu_units                    = 512
+memory                       = 1024
 
 ###
 # AWS VPC - networking.tf
@@ -64,7 +67,7 @@ rds_server_instance_class    = "db.t3.medium"
 # AWS Route 53 - route53.tf
 ###
 # Value should come from a TF_VAR environment variable (e.g. set in a Github Secret)
-# route53_zone_name = 
+# route53_zone_name =
 
 ###
 # Feature Flags
@@ -72,3 +75,19 @@ rds_server_instance_class    = "db.t3.medium"
 
 feature_redis  = false
 feature_shield = false
+
+
+###
+# Metrics Alarms
+###
+
+diagnosis_key_total_warn     = 9000
+diagnosis_key_total_critical = 13500
+
+claimed_one_time_code_total_warn     = 3000
+claimed_one_time_code_total_critical = 4500
+
+unclaimed_one_time_code_total_warn     = 250
+unclaimed_one_time_code_total_critical = 400
+
+enable_test_tools = false

--- a/server/aws/variables.tf
+++ b/server/aws/variables.tf
@@ -65,6 +65,16 @@ variable "max_capacity" {
   default = 10
 }
 
+variable "cpu_units" {
+  type    = number
+  default = 2048
+}
+
+variable "memory" {
+  type    = number
+  default = 4096
+}
+
 # Task Key Retrieval
 variable "ecs_key_retrieval_name" {
   type = string
@@ -198,4 +208,14 @@ variable "feature_redis" {
 
 variable "feature_shield" {
   type = bool
+}
+
+
+###
+# Testing Tools
+###
+
+variable "enable_test_tools" {
+  type    = bool
+  default = false
 }

--- a/server/aws/variables_metrics.tf
+++ b/server/aws/variables_metrics.tf
@@ -1,0 +1,23 @@
+variable "diagnosis_key_total_warn" {
+  type = number
+}
+
+variable "diagnosis_key_total_critical" {
+  type = number
+}
+
+variable "claimed_one_time_code_total_warn" {
+  type = number
+}
+
+variable "claimed_one_time_code_total_critical" {
+  type = number
+}
+
+variable "unclaimed_one_time_code_total_warn" {
+  type = number
+}
+
+variable "unclaimed_one_time_code_total_critical" {
+  type = number
+}

--- a/server/aws/waf.tf
+++ b/server/aws/waf.tf
@@ -454,6 +454,63 @@ resource "aws_wafv2_web_acl" "key_submission" {
     }
   }
 
+  rule {
+    name     = "ClearKeysURI"
+    priority = 202
+
+    action {
+      allow {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              uri_path {}
+            }
+            search_string = "/clear-diagnosis-keys"
+            text_transformation {
+              priority = 1
+              type     = "COMPRESS_WHITE_SPACE"
+            }
+            text_transformation {
+              priority = 2
+              type     = "LOWERCASE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            positional_constraint = "STARTS_WITH"
+            field_to_match {
+              single_header {
+                name = "authorization"
+              }
+            }
+            search_string = "Bearer"
+            text_transformation {
+              priority = 1
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          ip_set_reference_statement {
+            arn = aws_wafv2_ip_set.new_key_claim.arn
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "ClearKeysURI"
+      sampled_requests_enabled   = false
+    }
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }


### PR DESCRIPTION
Scale down ECS instances to 0.5 vcpu and 1 gig of ram
Scale down desired_count (will need to be rectified manually)
Sync with staging for new variables for alarms
Add Test tools (Will be disabled)

Related to https://github.com/cds-snc/covid-alert-server/issues/338