### PR TITLE
feat: downscale to smallest current gen burstable instance

### DIFF
--- a/server/aws/variables.auto.tfvars
+++ b/server/aws/variables.auto.tfvars
@@ -61,7 +61,7 @@ rds_server_db_user = "root"
 # Value should come from a TF_VAR environment variable (e.g. set in a Github Secret)
 # rds_server_db_password       = ""
 rds_server_allocated_storage = "5"
-rds_server_instance_class    = "db.t3.medium"
+rds_server_instance_class    = "db.t3.small"
 
 ###
 # AWS Route 53 - route53.tf


### PR DESCRIPTION
**Please Note: this will only take effect during the next maintenance window**

Related: https://github.com/cds-snc/covid-alert-server/issues/338

