### PR TITLE
feat: create IAM user for pipeline ECR tasks

### DIFF
--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Render image for retrieval service
         id: taskdef-retrieval
-        uses: aws-actions/amazon-ecs-render-task-definition@9666dc9
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.0.20
         with:
           task-definition: task-definition-retrieval.json
           container-name: ${{ steps.download-taskdef-retrieval.outputs.container_name }}
@@ -65,7 +65,7 @@ jobs:
 
       - name: Deploy image for retrieval service
         timeout-minutes: 10
-        uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.4.4
         with:
           task-definition: ${{ steps.taskdef-retrieval.outputs.task-definition }}
           service: KeyRetrieval
@@ -118,7 +118,7 @@ jobs:
 
       - name: Render image for submission service
         id: taskdef-submission
-        uses: aws-actions/amazon-ecs-render-task-definition@9666dc9
+        uses: aws-actions/amazon-ecs-render-task-definition@v1.0.20
         with:
           task-definition: task-definition-submission.json
           container-name: ${{ steps.download-taskdef-submission.outputs.container_name }}
@@ -133,7 +133,7 @@ jobs:
 
       - name: Deploy image for submission service
         timeout-minutes: 10
-        uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1.4.4
         with:
           task-definition: ${{ steps.taskdef-submission.outputs.task-definition }}
           service: KeySubmission

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check -no-color
+        continue-on-error: true
 
       - name: Terraform Init
         id: init
@@ -64,7 +65,6 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-        continue-on-error: true
 
       - name: Terraform Refresh
         id: refresh

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -56,12 +56,10 @@ jobs:
       - name: Terraform Format
         id: fmt
         run: terraform fmt -check -no-color
-        continue-on-error: true
 
       - name: Terraform Init
         id: init
-        run: |
-          terraform init
+        run: terraform init
 
       - name: Terraform Validate
         id: validate
@@ -127,8 +125,7 @@ jobs:
         run: terraform fmt -check
 
       - name: Terraform Init
-        run: |
-          terraform init
+        run: terraform init
 
       - name: Terraform Plan
         run: terraform plan -input=false -out terraform.tfplan

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
+        continue-on-error: true
 
       - name: Terraform Refresh
         id: refresh
@@ -102,7 +103,7 @@ jobs:
             })
 
       - name: Check Success
-        if: ${{ ( success()  ||  failure() ) && ( steps.fmt.outputs.exit_code  == 1 || steps.plan.outputs.exit_code == 1 ) }}
+        if: ${{ ( success() || failure() ) && ( steps.fmt.outputs.exit_code  > 0 || steps.plan.outputs.exit_code == 1 ) }}
         run: |
           echo steps.fmt.outcome ${{ steps.fmt.outcome }}
           echo steps.plan.outcome ${{ steps.plan.outcome }}

--- a/server/aws/iam.tf
+++ b/server/aws/iam.tf
@@ -176,3 +176,14 @@ resource "aws_iam_role_policy_attachment" "lambda_validate_deploy" {
   role       = aws_iam_role.lambda_validate_deploy.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
+
+# Interact with ECR in our GitHub workflows
+resource "aws_iam_user" "pipeline_ecr" {
+  name                 = "pipeline_ecr"
+  permissions_boundary = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}
+
+resource "aws_iam_user_policy_attachment" "pipeline_ecr_power_user_policy_attach" {
+  user       = aws_iam_user.pipeline_ecr.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+}

--- a/server/aws/lb.tf
+++ b/server/aws/lb.tf
@@ -48,8 +48,8 @@ resource "aws_lb_target_group" "covidshield_key_retrieval_2" {
   }
 }
 
-  # Logging is not required in the Demo environment
-  # tfsec:ignore:AWS0702
+# Logging is not required in the Demo environment
+# tfsec:ignore:AWS0702
 resource "aws_lb" "covidshield_key_retrieval" {
   name               = "covidshield-key-retrieval"
   internal           = false #tfsec:ignore:AWS005


### PR DESCRIPTION
This creates our ECR user, which we'll use in the `covid-alert-metrics` pipeline change.

It also:
* Fixes a bug with the `deploy-containers` workflow aws-actions (bumps to latest for both), and
* Fixes the `Check Success` step to catch PR workflows with failing `tf fmt` steps.
* ~~Makes the PR `terraform` workflow hard fail on a `tf fmt -check` because I completely missed it failing in my last PR~~ 

Fixes: #34 
Fixes: #38
Related: cds-snc/covid-alert-metrics#68

