### PR TITLE
fix: check step outcome to determine PR job status

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -103,11 +103,10 @@ jobs:
             })
 
       - name: Check Success
-        if: ${{ ( success() || failure() ) && ( steps.fmt.outputs.exit_code  > 0 || steps.plan.outputs.exit_code == 1 ) }}
+        if: ${{ steps.fmt.outcome == 'failure' || steps.plan.outcome == 'failure'  }}
         run: |
-          echo steps.fmt.outcome ${{ steps.fmt.outcome }}
-          echo steps.plan.outcome ${{ steps.plan.outcome }}
-          echo "(${{ steps.fmt.outcome }} == failure || ${{ steps.plan.outcome }} == failure)"
+          echo "steps.fmt.outcome == ${{ steps.fmt.outcome }}"
+          echo "steps.plan.outcome == ${{ steps.plan.outcome }}"
           exit 1
 
   terraform-apply:

--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -3,7 +3,7 @@
 ###
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
-  comment = "cloudfront origin access identity"
+    comment = "cloudfront origin access identity"
 }
 
 resource "aws_cloudfront_distribution" "key_retrieval_distribution" {

--- a/server/aws/cloudfront.tf
+++ b/server/aws/cloudfront.tf
@@ -3,7 +3,7 @@
 ###
 
 resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
-    comment = "cloudfront origin access identity"
+  comment = "cloudfront origin access identity"
 }
 
 resource "aws_cloudfront_distribution" "key_retrieval_distribution" {


### PR DESCRIPTION
Switch to checking step `outcome == 'failure'` to see if the PR workflow succeeded.

Fixes: #40 
